### PR TITLE
Pin Kazoo version to 2.5.0 in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -35,6 +35,7 @@ deps =
 	zake
 	snmpsim
 	testfixtures
+    kazoo==2.5.0
 commands = 
 	{envpython} {envbindir}/nosetests --with-xunit \
 	--xunit-file=nosetests_{envname}.xml \


### PR DESCRIPTION
Newer versions don't work with the version of Zookeeper in the test environment