### PR TITLE
Upgrade version of yahoo_panoptes_snmp we depend on to 0.2.5.121

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     ratelimitingfilter
     redis
     requests
-    yahoo_panoptes_snmp>=0.2.5.115
+    yahoo_panoptes_snmp>=0.2.5.121
     yapsy
 
 packages = find:


### PR DESCRIPTION
The newest version of yahoo_panoptes_snmp installs and works on MacOS X in addition to Linux

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
