### PR TITLE
Use an IP from RFC 5737 to test failure conditions

### DIFF
--- a/tests/plugins/polling/generic/snmp/data/from_file_no_service_active_results.json
+++ b/tests/plugins/polling/generic/snmp/data/from_file_no_service_active_results.json
@@ -7,7 +7,7 @@
       "resource_class": "network",
       "resource_plugin": "dummy",
       "resource_subclass": "test_subclass",
-      "resource_endpoint": "127.0.0.2",
+      "resource_endpoint": "192.0.2.1",
       "resource_metadata": {
         "model": "model",
         "_resource_ttl": "604800"
@@ -33,7 +33,7 @@
       "resource_class": "network",
       "resource_plugin": "dummy",
       "resource_subclass": "test_subclass",
-      "resource_endpoint": "127.0.0.2",
+      "resource_endpoint": "192.0.2.1",
       "resource_metadata": {
         "model": "model",
         "_resource_ttl": "604800"
@@ -64,7 +64,7 @@
       "resource_class": "network",
       "resource_plugin": "dummy",
       "resource_subclass": "test_subclass",
-      "resource_endpoint": "127.0.0.2",
+      "resource_endpoint": "192.0.2.1",
       "resource_metadata": {
         "model": "model",
         "_resource_ttl": "604800"
@@ -90,7 +90,7 @@
       "resource_class": "network",
       "resource_plugin": "dummy",
       "resource_subclass": "test_subclass",
-      "resource_endpoint": "127.0.0.2",
+      "resource_endpoint": "192.0.2.1",
       "resource_metadata": {
         "model": "model",
         "_resource_ttl": "604800"
@@ -103,7 +103,7 @@
       {
         "metric_type": "gauge",
         "metric_name": "polling_status",
-        "metric_value": 3
+        "metric_value": 7
       }
     ],
     "metrics_group_schema_version": "0.2"

--- a/tests/plugins/polling/generic/snmp/test_generic_snmp_polling_plugin.py
+++ b/tests/plugins/polling/generic/snmp/test_generic_snmp_polling_plugin.py
@@ -103,7 +103,7 @@ class TestPluginPollingGenericSNMPFeaturesEnrichmentFromFile(TestPluginPollingGe
 
     def test_no_service_active(self):
         """Tests a valid resource_endpoint with no service active"""
-        self._resource_endpoint = '127.0.0.2'
+        self._resource_endpoint = '192.0.2.1' # Per RFC 5737
         self._snmp_conf['timeout'] = self._snmp_failure_timeout
         self.results_data_file = "from_file_no_service_active_results.json"
         self.set_panoptes_resource()


### PR DESCRIPTION
The test IP currently being used (127.0.0.2) might actually be present in the build environment, leading to flaky tests

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
