### PR TITLE
Juniper EX4300 CPU Util Oid Update

### DIFF
--- a/tests/plugins/enrichment/generic/snmp/juniper/data/ex4300_results.json
+++ b/tests/plugins/enrichment/generic/snmp/juniper/data/ex4300_results.json
@@ -1,0 +1,167 @@
+{
+    "enrichment": [
+        {
+            "data": [
+                {
+                    "127.0.0.1": {
+                        "metrics_groups": [
+                            {
+                                "dimensions": {
+                                    "sensor": "temp_sensor_name.$index"
+                                },
+                                "group_name": "environment",
+                                "metrics": {
+                                    "temperature_fahrenheit": {
+                                        "metric_type": "gauge",
+                                        "transform": "lambda x: round((x * 1.8) + 32, 2) if x != 0 else 0.0",
+                                        "type": "float",
+                                        "value": "temp_sensor_values.$index"
+                                    }
+                                }
+                            },
+                            {
+                                "dimensions": {
+                                    "cpu_name": "cpu_name.$index",
+                                    "cpu_no": "cpu_no.$index",
+                                    "cpu_type": "'data' if 'Routing Engine' in cpu_name.$index else 'ctrl'"
+                                },
+                                "group_name": "cpu",
+                                "metrics": {
+                                    "cpu_utilization": {
+                                        "metric_type": "gauge",
+                                        "value": "cpu_util.$index"
+                                    }
+                                }
+                            },
+                            {
+                                "dimensions": {
+                                    "memory_type": "cpu_name.$index"
+                                },
+                                "group_name": "memory",
+                                "metrics": {
+                                    "memory_total": {
+                                        "metric_type": "gauge",
+                                        "value": "memory_total.$index"
+                                    },
+                                    "memory_used": {
+                                        "indices_from": "memory_total",
+                                        "metric_type": "gauge",
+                                        "value": "float(memory_used.$index) / 100.0 * memory_total.$index"
+                                    }
+                                }
+                            },
+                            {
+                                "dimensions": {},
+                                "group_name": "environment",
+                                "metrics": {
+                                    "fans_ok": {
+                                        "metric_type": "gauge",
+                                        "value": "len([(x,y) for (x,y) in oper_status.items() if x in fans and y not in ['6']])"
+                                    },
+                                    "fans_total": 5
+                                }
+                            }
+                        ],
+                        "oids": {
+                            "cpu_name": {
+                                "method": "static",
+                                "values": {
+                                    "7.1.0.0": "FPC: EX4600-40F @ 0/*/*",
+                                    "8.1.1.0": "PIC: 24x10G-4x40G @ 0/0/*",
+                                    "8.1.2.0": "PIC: EX4600-EM-8F @ 0/1/*",
+                                    "8.1.3.0": "PIC: EX4600-EM-8F @ 0/2/*",
+                                    "9.1.0.0": "Routing Engine 0"
+                                }
+                            },
+                            "cpu_no": {
+                                "method": "static",
+                                "values": {
+                                    "7.1.0.0": "Module 7.1.0.0",
+                                    "8.1.1.0": "Module 8.1.1.0",
+                                    "8.1.2.0": "Module 8.1.2.0",
+                                    "8.1.3.0": "Module 8.1.3.0",
+                                    "9.1.0.0": "Module 9.1.0.0"
+                                }
+                            },
+                            "cpu_util": {
+                                "method": "bulk_walk",
+                                "oid": ".1.3.6.1.4.1.2636.3.1.13.1.8"
+                            },
+                            "fans": {
+                                "method": "static",
+                                "values": {
+                                    "4.1.1.0": "Fan Tray 0 @ 0/0/*",
+                                    "4.1.2.0": "Fan Tray 1 @ 0/1/*",
+                                    "4.1.3.0": "Fan Tray 2 @ 0/2/*",
+                                    "4.1.4.0": "Fan Tray 3 @ 0/3/*",
+                                    "4.1.5.0": "Fan Tray 4 @ 0/4/*"
+                                }
+                            },
+                            "memory_total": {
+                                "method": "static",
+                                "values": {
+                                    "7.1.0.0": 2013265920,
+                                    "9.1.0.0": 2013265920
+                                }
+                            },
+                            "memory_used": {
+                                "method": "bulk_walk",
+                                "oid": ".1.3.6.1.4.1.2636.3.1.13.1.11"
+                            },
+                            "oper_status": {
+                                "method": "bulk_walk",
+                                "oid": ".1.3.6.1.4.1.2636.3.1.13.1.6"
+                            },
+                            "power_module_types": {
+                                "method": "static",
+                                "values": {}
+                            },
+                            "power_modules": {
+                                "method": "static",
+                                "values": {}
+                            },
+                            "power_units_total": {
+                                "method": "static",
+                                "values": {}
+                            },
+                            "temp_sensor_name": {
+                                "method": "static",
+                                "values": {
+                                    "7.1.0.0": "FPC: EX4600-40F @ 0/*/*",
+                                    "8.1.2.0": "PIC: EX4600-EM-8F @ 0/1/*",
+                                    "8.1.3.0": "PIC: EX4600-EM-8F @ 0/2/*",
+                                    "9.1.0.0": "Routing Engine 0"
+                                }
+                            },
+                            "temp_sensor_values": {
+                                "method": "bulk_walk",
+                                "oid": ".1.3.6.1.4.1.2636.3.1.13.1.7"
+                            }
+                        }
+                    }
+                }
+            ],
+            "metadata": {
+                "_enrichment_group_creation_timestamp": 1512629517.03121,
+                "_enrichment_ttl": 300,
+                "_execute_frequency": 60
+            },
+            "namespace": "metrics"
+        }
+    ],
+    "enrichment_group_set_creation_timestamp": 1512629517.03121,
+    "resource": {
+        "resource_class": "network",
+        "resource_creation_timestamp": 1512629517.03121,
+        "resource_endpoint": "127.0.0.1",
+        "resource_id": "test_id",
+        "resource_metadata": {
+            "_resource_ttl": "604800",
+            "model": "EX4300-48P"
+        },
+        "resource_plugin": "dummy",
+        "resource_site": "test_site",
+        "resource_subclass": "test_subclass",
+        "resource_type": "test_type"
+    }
+}

--- a/tests/plugins/enrichment/generic/snmp/juniper/test_plugin_enrichment_juniper_device_metrics.py
+++ b/tests/plugins/enrichment/generic/snmp/juniper/test_plugin_enrichment_juniper_device_metrics.py
@@ -83,3 +83,10 @@ class TestPluginQFX(PluginJuniperDeviceMetricsEnrichment, unittest.TestCase):
 class TestPluginEX(PluginJuniperDeviceMetricsEnrichment, unittest.TestCase):
     results_data_file = 'ex_results.json'
     snmp_community = 'ex'
+
+
+class TestPluginEX4300(PluginJuniperDeviceMetricsEnrichment, unittest.TestCase):
+    resource_model = 'EX4300-48P'
+    results_data_file = 'ex4300_results.json'
+    snmp_community = 'ex'
+

--- a/yahoo_panoptes/plugins/enrichment/generic/snmp/juniper/plugin_enrichment_juniper_device_metrics.py
+++ b/yahoo_panoptes/plugins/enrichment/generic/snmp/juniper/plugin_enrichment_juniper_device_metrics.py
@@ -157,7 +157,8 @@ class JuniperPluginEnrichmentDeviceMetrics(plugin_enrichment_generic_snmp.Panopt
             },
             u"cpu_util": {
                 u"method": u"bulk_walk",
-                u"oid": self._get_cpu_interval()
+                u"oid": MibJuniper.jnxOperatingCPU.oid if 'EX4300' in self._juniper_model else
+                    self._get_cpu_interval()
             },
             u"memory_used": {
                 u"method": u"bulk_walk",


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
Updating the oid used to query EX4300 devices. 

There are no 1 / 5 / 15 minute cpu utilization metrics on the device. 

SNMPWalk of jnxOperating(1|5|15)MinAvgCPU all return 100. The command 'show chassis routing-engine' only provides the 5 second metric jnxOperatingCPU.


I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
