### PR TITLE
Scheduler Task Thread - Update Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ We welcome issues, questions, and pull requests. Please read the [contributing g
 * Vivekanand AM: viveka@verizonmedia.com
 * Ian Holmes: iholmes@verizonmedia.com
 * James Diss: rexfury@verizonmedia.com
-* Nathan Kamm: nathan.kamm@verizonmedia.com
 
 ## License
 This project is licensed under the terms of the Apache 2.0 open source license. Please refer to [LICENSE](https://github.com/yahoo/panoptes/blob/master/LICENSE) for the full terms.

--- a/yahoo_panoptes/framework/plugins/scheduler.py
+++ b/yahoo_panoptes/framework/plugins/scheduler.py
@@ -162,7 +162,6 @@ class PanoptesPluginScheduler(object):
         """
         logger = self._logger
         logger.info(u'%s Plugin Scheduler Task thread: OS PID: %d' % (self._plugin_type_display_name, get_os_tid()))
-
         while not self._shutdown_plugin_scheduler.is_set():
             if self._lock.locked:
                 self._cycles_without_lock = 0
@@ -179,7 +178,7 @@ class PanoptesPluginScheduler(object):
                                 self._plugin_type_display_name)
                 else:
                     logger.warn(u'%s Plugin Scheduler lock not held for %d cycles, shutting down' %
-                                self._plugin_type_display_name, self._cycles_without_lock)
+                                (self._plugin_type_display_name, self._cycles_without_lock))
                     self._shutdown()
 
             if self._tour_of_duty.completed:
@@ -188,7 +187,7 @@ class PanoptesPluginScheduler(object):
                 why += [u'time'] if self._tour_of_duty.time_completed else []
                 why += [u'memory growth'] if self._tour_of_duty.memory_growth_completed else []
 
-                logger.info(u'%s Plugin Scheduler "Tour Of Duty" completed because of %sgoing to shutdown' %
+                logger.info(u'%s Plugin Scheduler "Tour Of Duty" completed because of %s going to shutdown' %
                             (self._plugin_type_display_name, ', '.join(why)))
                 self._shutdown()
             self._shutdown_plugin_scheduler.wait(self._config[self._plugin_type][u'plugin_scan_interval'])


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

Logging issue on task thread causes exception which halts thread.

```
[WARNING/MainProcess] Exception in thread Thread-4:
Traceback (most recent call last):
File "/home/python3.6/threading.py", line 916, in _bootstrap_inner
     self.run()
   File "/home/python3.6/threading.py", line 864, in run
     self._target(*self._args, **self._kwargs)
   File "/home/panoptes/yahoo_panoptes/framework/plugins/scheduler.py", line 182, in _plugin_scheduler_task_thread
     self._plugin_type_display_name, self._cycles_without_lock)
 TypeError: not enough arguments for format string
```