### PR TITLE
PanoptesMetricDimension - Remove Check On Value

### DIFF
--- a/tests/test_framework_metrics.py
+++ b/tests/test_framework_metrics.py
@@ -216,7 +216,9 @@ class TestMetrics(unittest.TestCase):
         with self.assertRaises(ValueError):
             PanoptesMetricDimension(u'contain$_invalid_character$', u'bar')
         with self.assertRaises(ValueError):
-            PanoptesMetricDimension(u'foo', u'contains_pipe|')
+            PanoptesMetricDimension(u'contains_pipe|', u'foo')
+
+        self.assertEqual(u'|', PanoptesMetricDimension(u'foo', u'|').value)
 
         dimension_one = PanoptesMetricDimension(u'if_alias', u'bar')
 

--- a/yahoo_panoptes/framework/metrics.py
+++ b/yahoo_panoptes/framework/metrics.py
@@ -160,6 +160,10 @@ class PanoptesMetric(object):
 
 
 class PanoptesMetricDimension(object):
+    """
+    Dimension Name Regex: ^[^\d\W]\w*\Z
+    Dimension Value Regex: .+
+    """
     def __init__(self, name, value):
         assert name and isinstance(name, string_types), (
             u'dimension name must be non-empty str or unicode, is type %s' % type(name))
@@ -169,9 +173,6 @@ class PanoptesMetricDimension(object):
         if not _VALID_KEY.match(name):
             raise ValueError(
                     u'dimension name "%s" has to match pattern: (letter|"_") (letter | digit | "_")*' % name)
-
-        if u'|' in value:
-            raise ValueError(u'dimension value "%s" cannot contain |' % value)
 
         self.__data = dict()
 


### PR DESCRIPTION
Metric collector dimension/label value regex is .+ which allows pipes. Blocking | in dimension values may cause issues processing collected interface descriptions.
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
